### PR TITLE
Update general.py

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -893,6 +893,9 @@ def output_to_target(output, width, height):
     targets = []
     for i, o in enumerate(output):
         if o is not None:
+            # sometimes output can be a list of tensor, so here ensure the type again, this fixes the error.
+            if isinstance(o, torch.Tensor):
+                o = o.cpu().numpy()
             for pred in o:
                 box = pred[:4]
                 w = (box[2] - box[0]) / width


### PR DESCRIPTION
To fix the error "can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first".
Thanks [@glenn-jocher](https://github.com/glenn-jocher) (https://github.com/ultralytics/yolov5/issues/2106)